### PR TITLE
Fix exception in nix/dev-container

### DIFF
--- a/nix/dev-container
+++ b/nix/dev-container
@@ -11,5 +11,5 @@ fi
 nixos-container start pepa-dev
 
 if [ $initial ]; then
-    $root/psql < "$root/../db/schema.sql"
+    $root/psql < "$root/../resources/schema.sql"
 fi


### PR DESCRIPTION
Database wasn't initialized so "nix/lein run" threw PostreSQL exceptions